### PR TITLE
pin cortex-python to 1.3.1

### DIFF
--- a/Tutorial/titanic_survivor_prediction/requirements_local.txt
+++ b/Tutorial/titanic_survivor_prediction/requirements_local.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 scikit-learn==0.20.3
 seaborn==0.10.0
-cortex-python==1.1.0
+cortex-python==1.3.1

--- a/all/requirements_local.txt
+++ b/all/requirements_local.txt
@@ -2,7 +2,7 @@ numpy==1.17.3
 scikit-learn==0.20.3
 pandas==0.25.3
 Flask==1.1.1
-cortex-python==1.1.0
+cortex-python==1.3.1
 xgboost==0.90
 keras==2.3.1
 tensorflow==1.15.2

--- a/build-package/certifaiReferenceModelServer/all/requirements_local.txt
+++ b/build-package/certifaiReferenceModelServer/all/requirements_local.txt
@@ -2,5 +2,5 @@ numpy==1.17.3
 scikit-learn==0.20.3
 pandas==0.25.3
 Flask==1.1.1
-cortex-python==1.1.0
+cortex-python==1.3.1
 keras==2.3.1

--- a/build-package/requirements_local.txt
+++ b/build-package/requirements_local.txt
@@ -2,5 +2,5 @@ numpy==1.17.3
 scikit-learn==0.20.3
 pandas==0.25.3
 Flask==1.1.1
-cortex-python==1.1.0
+cortex-python==1.3.1
 keras==2.3.1

--- a/build-package/setup.py
+++ b/build-package/setup.py
@@ -35,7 +35,7 @@ setup(name='cortex-certifai-reference-model-server',
         'scikit-learn==0.20.3',
         'pandas==0.24.2',
         'Flask==1.1.1',
-        'cortex-python==1.1.0',
+        'cortex-python==1.3.1',
         'keras==2.3.1',
       ],
 


### PR DESCRIPTION
Addresses cognitivescale/certifai#2022

Changes have been tested for the `bank_marketing` (Trained and tested from scratch via s2i)