### PR TITLE
Changes to stop conversion warning in diabetes model on predict

### DIFF
--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/common_utils/train_utils.py
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/common_utils/train_utils.py
@@ -1,2 +1,14 @@
+from sklearn.preprocessing import StandardScaler
+
 def prep_diabetes_dataset(data):  # we assume a pre-cleaned dataset
     return data[(data.BloodPressure != 0) & (data.BMI != 0) & (data.Glucose != 0)]
+
+
+class WrappedStandardScaler(StandardScaler):
+    # all of the data is numeric in this example and needs to be treated as float to avoid warnings
+    def fit(self, d, **kwargs):
+        return super().fit(d.astype(float), **kwargs)
+
+    def transform(self, d, **kwargs):
+        # all of the data is numeric and needs to be treated as float
+        return super().transform(d.astype(float), **kwargs)

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/decisionTree/predict.py
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/decisionTree/predict.py
@@ -1,6 +1,5 @@
 import numpy as np
 import os
-import pickle
 import sys
 from certifaiReferenceModelServer.utils.encode_decode import init_model
 from certifaiReferenceModelServer.utils.local_server import assemble_server

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/decisionTree/train.py
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/decisionTree/train.py
@@ -6,7 +6,8 @@ from sklearn.preprocessing import StandardScaler
 import pandas as pd
 import numpy as np
 from sklearn.tree import DecisionTreeClassifier
-from certifaiReferenceModelServer.healthcare_disease_prediction.common_utils.train_utils import prep_diabetes_dataset
+from certifaiReferenceModelServer.healthcare_disease_prediction.common_utils.train_utils import \
+    prep_diabetes_dataset, WrappedStandardScaler
 from certifaiReferenceModelServer.utils.encode_decode import pickle_model
 
 RANDOM_SEED = 0
@@ -37,7 +38,7 @@ def train(msg):
     X_test_df = test_data.drop("Outcome", axis=1)
 
     # create encoder on entire dataset
-    scaler = StandardScaler(copy=True, with_mean=True, with_std=True)
+    scaler = WrappedStandardScaler(copy=True, with_mean=True, with_std=True)
     scaler.fit(X)
 
     # apply encoding to train and test data features

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/logisticRegression/predict.py
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/logisticRegression/predict.py
@@ -1,6 +1,5 @@
 import numpy as np
 import os
-import pickle
 import sys
 from certifaiReferenceModelServer.utils.encode_decode import init_model
 from certifaiReferenceModelServer.utils.local_server import assemble_server

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/logisticRegression/train.py
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/logisticRegression/train.py
@@ -6,7 +6,8 @@ import pandas as pd
 import numpy as np
 from sklearn.preprocessing import StandardScaler
 from sklearn.linear_model import LogisticRegression
-from certifaiReferenceModelServer.healthcare_disease_prediction.common_utils.train_utils import prep_diabetes_dataset
+from certifaiReferenceModelServer.healthcare_disease_prediction.common_utils.train_utils import \
+    prep_diabetes_dataset, WrappedStandardScaler
 from certifaiReferenceModelServer.utils.encode_decode import pickle_model
 
 RANDOM_SEED = 0
@@ -37,7 +38,7 @@ def train(msg):
     X_test_df = test_data.drop("Outcome", axis=1)
 
     # create encoder on entire dataset
-    scaler = StandardScaler(copy=True, with_mean=True, with_std=True)
+    scaler = WrappedStandardScaler(copy=True, with_mean=True, with_std=True)
     scaler.fit(X)
 
     # apply encoding to train and test data features

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/multiLayerPerceptron/predict.py
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/multiLayerPerceptron/predict.py
@@ -1,6 +1,5 @@
 import numpy as np
 import os
-import pickle
 import sys
 from certifaiReferenceModelServer.utils.encode_decode import init_model
 from certifaiReferenceModelServer.utils.local_server import assemble_server

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/multiLayerPerceptron/train.py
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/multiLayerPerceptron/train.py
@@ -6,7 +6,8 @@ import pandas as pd
 import numpy as np
 from sklearn.preprocessing import StandardScaler
 from sklearn.neural_network import MLPClassifier
-from certifaiReferenceModelServer.healthcare_disease_prediction.common_utils.train_utils import prep_diabetes_dataset
+from certifaiReferenceModelServer.healthcare_disease_prediction.common_utils.train_utils import \
+    prep_diabetes_dataset, WrappedStandardScaler
 from certifaiReferenceModelServer.utils.encode_decode import pickle_model
 
 RANDOM_SEED = 0
@@ -37,7 +38,7 @@ def train(msg):
     X_test_df = test_data.drop("Outcome", axis=1)
 
     # create encoder on entire dataset
-    scaler = StandardScaler(copy=True, with_mean=True, with_std=True)
+    scaler = WrappedStandardScaler(copy=True, with_mean=True, with_std=True)
     scaler.fit(X)
 
     # apply encoding to train and test data features

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/supportVectorMachine/predict.py
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/supportVectorMachine/predict.py
@@ -1,6 +1,5 @@
 import numpy as np
 import os
-import pickle
 import sys
 from certifaiReferenceModelServer.utils.encode_decode import init_model
 from certifaiReferenceModelServer.utils.local_server import assemble_server

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/supportVectorMachine/train.py
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/supportVectorMachine/train.py
@@ -6,7 +6,8 @@ import pandas as pd
 import numpy as np
 from sklearn.preprocessing import StandardScaler
 from sklearn import svm
-from certifaiReferenceModelServer.healthcare_disease_prediction.common_utils.train_utils import prep_diabetes_dataset
+from certifaiReferenceModelServer.healthcare_disease_prediction.common_utils.train_utils import \
+    prep_diabetes_dataset, WrappedStandardScaler
 from certifaiReferenceModelServer.utils.encode_decode import pickle_model
 
 RANDOM_SEED = 0
@@ -37,7 +38,7 @@ def train(msg):
     X_test_df = test_data.drop("Outcome", axis=1)
 
     # create encoder on entire dataset
-    scaler = StandardScaler(copy=True, with_mean=True, with_std=True)
+    scaler = WrappedStandardScaler(copy=True, with_mean=True, with_std=True)
     scaler.fit(X)
 
     # apply encoding to train and test data features

--- a/build-package/setup.py
+++ b/build-package/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup
 with open('README.md', 'r') as f:
     long_description = f.read()
 
-__version__ = '1.2.12'
+__version__ = '1.2.15'
 
 setup(name='cortex-certifai-reference-model-server',
       description="Python Package for the CognitiveScale Cortex Certifai Reference Models",

--- a/healthcare_disease_prediction/common_utils/train_utils.py
+++ b/healthcare_disease_prediction/common_utils/train_utils.py
@@ -1,2 +1,14 @@
+from sklearn.preprocessing import StandardScaler
+
 def prep_diabetes_dataset(data):  # we assume a pre-cleaned dataset
     return data[(data.BloodPressure != 0) & (data.BMI != 0) & (data.Glucose != 0)]
+
+
+class WrappedStandardScaler(StandardScaler):
+    # all of the data is numeric in this example and needs to be treated as float to avoid warnings
+    def fit(self, d, **kwargs):
+        return super().fit(d.astype(float), **kwargs)
+
+    def transform(self, d, **kwargs):
+        # all of the data is numeric and needs to be treated as float
+        return super().transform(d.astype(float), **kwargs)

--- a/healthcare_disease_prediction/decisionTree/predict.py
+++ b/healthcare_disease_prediction/decisionTree/predict.py
@@ -1,6 +1,5 @@
 import numpy as np
 import os
-import pickle
 import sys
 from utils.encode_decode import init_model
 from utils.local_server import assemble_server
@@ -28,8 +27,13 @@ def predict(model_ctx, instances):
         instances = scaler.transform(instances)
 
     predictions = model_obj["model"].predict(instances)
-    return {"predictions": predictions.tolist()}
-
+    scores = model_obj["model"].predict_proba(instances)
+    labels = model_obj["model"].classes_
+    return {
+        "predictions": predictions.tolist(),
+        "scores": scores.tolist(),
+        "labels": labels.tolist()
+    }
 
 if __name__ == "__main__":
     assemble_server(sys.argv[1])

--- a/healthcare_disease_prediction/decisionTree/train.py
+++ b/healthcare_disease_prediction/decisionTree/train.py
@@ -2,11 +2,10 @@ from cortex import Cortex, Message
 import json
 import sys
 import random
-from sklearn.preprocessing import StandardScaler
 import pandas as pd
 import numpy as np
 from sklearn.tree import DecisionTreeClassifier
-from healthcare_disease_prediction.common_utils.train_utils import prep_diabetes_dataset
+from healthcare_disease_prediction.common_utils.train_utils import prep_diabetes_dataset, WrappedStandardScaler
 from utils.encode_decode import pickle_model
 
 RANDOM_SEED = 0
@@ -37,7 +36,7 @@ def train(msg):
     X_test_df = test_data.drop("Outcome", axis=1)
 
     # create encoder on entire dataset
-    scaler = StandardScaler(copy=True, with_mean=True, with_std=True)
+    scaler = WrappedStandardScaler(copy=True, with_mean=True, with_std=True)
     scaler.fit(X)
 
     # apply encoding to train and test data features

--- a/healthcare_disease_prediction/logisticRegression/predict.py
+++ b/healthcare_disease_prediction/logisticRegression/predict.py
@@ -1,6 +1,5 @@
 import numpy as np
 import os
-import pickle
 import sys
 from utils.encode_decode import init_model
 from utils.local_server import assemble_server

--- a/healthcare_disease_prediction/logisticRegression/train.py
+++ b/healthcare_disease_prediction/logisticRegression/train.py
@@ -4,9 +4,9 @@ import sys
 import random
 import pandas as pd
 import numpy as np
-from sklearn.preprocessing import StandardScaler
 from sklearn.linear_model import LogisticRegression
-from healthcare_disease_prediction.common_utils.train_utils import prep_diabetes_dataset
+from healthcare_disease_prediction.common_utils.train_utils import prep_diabetes_dataset, \
+    WrappedStandardScaler
 from utils.encode_decode import pickle_model
 
 RANDOM_SEED = 0
@@ -37,7 +37,7 @@ def train(msg):
     X_test_df = test_data.drop("Outcome", axis=1)
 
     # create encoder on entire dataset
-    scaler = StandardScaler(copy=True, with_mean=True, with_std=True)
+    scaler = WrappedStandardScaler(copy=True, with_mean=True, with_std=True)
     scaler.fit(X)
 
     # apply encoding to train and test data features

--- a/healthcare_disease_prediction/multiLayerPerceptron/predict.py
+++ b/healthcare_disease_prediction/multiLayerPerceptron/predict.py
@@ -1,6 +1,5 @@
 import numpy as np
 import os
-import pickle
 import sys
 from utils.encode_decode import init_model
 from utils.local_server import assemble_server

--- a/healthcare_disease_prediction/multiLayerPerceptron/train.py
+++ b/healthcare_disease_prediction/multiLayerPerceptron/train.py
@@ -4,9 +4,8 @@ import sys
 import random
 import pandas as pd
 import numpy as np
-from sklearn.preprocessing import StandardScaler
 from sklearn.neural_network import MLPClassifier
-from healthcare_disease_prediction.common_utils.train_utils import prep_diabetes_dataset
+from healthcare_disease_prediction.common_utils.train_utils import prep_diabetes_dataset, WrappedStandardScaler
 from utils.encode_decode import pickle_model
 
 RANDOM_SEED = 0
@@ -37,7 +36,7 @@ def train(msg):
     X_test_df = test_data.drop("Outcome", axis=1)
 
     # create encoder on entire dataset
-    scaler = StandardScaler(copy=True, with_mean=True, with_std=True)
+    scaler = WrappedStandardScaler(copy=True, with_mean=True, with_std=True)
     scaler.fit(X)
 
     # apply encoding to train and test data features

--- a/healthcare_disease_prediction/supportVectorMachine/predict.py
+++ b/healthcare_disease_prediction/supportVectorMachine/predict.py
@@ -1,6 +1,5 @@
 import numpy as np
 import os
-import pickle
 import sys
 from utils.encode_decode import init_model
 from utils.local_server import assemble_server

--- a/healthcare_disease_prediction/supportVectorMachine/train.py
+++ b/healthcare_disease_prediction/supportVectorMachine/train.py
@@ -4,9 +4,9 @@ import sys
 import random
 import pandas as pd
 import numpy as np
-from sklearn.preprocessing import StandardScaler
 from sklearn import svm
-from healthcare_disease_prediction.common_utils.train_utils import prep_diabetes_dataset
+from healthcare_disease_prediction.common_utils.train_utils import prep_diabetes_dataset, \
+    WrappedStandardScaler
 from utils.encode_decode import pickle_model
 
 RANDOM_SEED = 0
@@ -37,7 +37,7 @@ def train(msg):
     X_test_df = test_data.drop("Outcome", axis=1)
 
     # create encoder on entire dataset
-    scaler = StandardScaler(copy=True, with_mean=True, with_std=True)
+    scaler = WrappedStandardScaler(copy=True, with_mean=True, with_std=True)
     scaler.fit(X)
 
     # apply encoding to train and test data features


### PR DESCRIPTION
I know this is a minor thing, but it does create a lot of spam for people running diabetes tests with packaged ref model server. I did also change and test the s2i-dockerized models, to keep the code consistent.