### PR TITLE
Update scikit-learn version to v0.23.1

### DIFF
--- a/Tutorial/titanic_survivor_prediction/requirements.txt
+++ b/Tutorial/titanic_survivor_prediction/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 seaborn==0.10.0

--- a/Tutorial/titanic_survivor_prediction/requirements_local.txt
+++ b/Tutorial/titanic_survivor_prediction/requirements_local.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 seaborn==0.10.0
 cortex-python==1.3.1

--- a/all/requirements.txt
+++ b/all/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3
 xgboost==0.90
 keras==2.3.1

--- a/all/requirements_local.txt
+++ b/all/requirements_local.txt
@@ -1,5 +1,5 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3
 Flask==1.1.1
 cortex-python==1.3.1

--- a/bank_marketing/all/requirements.txt
+++ b/bank_marketing/all/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/bank_marketing/decisionTree/requirements_predict.txt
+++ b/bank_marketing/decisionTree/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/bank_marketing/decisionTree/requirements_train.txt
+++ b/bank_marketing/decisionTree/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/bank_marketing/logisticRegression/requirements_predict.txt
+++ b/bank_marketing/logisticRegression/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/bank_marketing/logisticRegression/requirements_train.txt
+++ b/bank_marketing/logisticRegression/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/bank_marketing/multiLayerPerceptron/requirements_predict.txt
+++ b/bank_marketing/multiLayerPerceptron/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/bank_marketing/multiLayerPerceptron/requirements_train.txt
+++ b/bank_marketing/multiLayerPerceptron/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/bank_marketing/supportVectorMachine/requirements_predict.txt
+++ b/bank_marketing/supportVectorMachine/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/bank_marketing/supportVectorMachine/requirements_train.txt
+++ b/bank_marketing/supportVectorMachine/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/banking_customer_churn_prediction/all/requirements.txt
+++ b/banking_customer_churn_prediction/all/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/banking_customer_churn_prediction/gradientBoosting/requirements_predict.txt
+++ b/banking_customer_churn_prediction/gradientBoosting/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/banking_customer_churn_prediction/gradientBoosting/requirements_train.txt
+++ b/banking_customer_churn_prediction/gradientBoosting/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/banking_customer_churn_prediction/multiLayerPerceptron/requirements_predict.txt
+++ b/banking_customer_churn_prediction/multiLayerPerceptron/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/banking_customer_churn_prediction/multiLayerPerceptron/requirements_train.txt
+++ b/banking_customer_churn_prediction/multiLayerPerceptron/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/banking_customer_churn_prediction/randomForest/requirements_predict.txt
+++ b/banking_customer_churn_prediction/randomForest/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/banking_customer_churn_prediction/randomForest/requirements_train.txt
+++ b/banking_customer_churn_prediction/randomForest/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/banking_customer_churn_prediction/supportVectorMachine/requirements_predict.txt
+++ b/banking_customer_churn_prediction/supportVectorMachine/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/banking_customer_churn_prediction/supportVectorMachine/requirements_train.txt
+++ b/banking_customer_churn_prediction/supportVectorMachine/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/banking_loan_approval/all/requirements.txt
+++ b/banking_loan_approval/all/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/banking_loan_approval/decisionTree/requirements_predict.txt
+++ b/banking_loan_approval/decisionTree/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/banking_loan_approval/decisionTree/requirements_train.txt
+++ b/banking_loan_approval/decisionTree/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/banking_loan_approval/logisticRegression/requirements_predict.txt
+++ b/banking_loan_approval/logisticRegression/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/banking_loan_approval/logisticRegression/requirements_train.txt
+++ b/banking_loan_approval/logisticRegression/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/banking_loan_approval/multiLayerPerceptron/requirements_predict.txt
+++ b/banking_loan_approval/multiLayerPerceptron/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/banking_loan_approval/multiLayerPerceptron/requirements_train.txt
+++ b/banking_loan_approval/multiLayerPerceptron/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/banking_loan_approval/supportVectorMachine/requirements_predict.txt
+++ b/banking_loan_approval/supportVectorMachine/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/banking_loan_approval/supportVectorMachine/requirements_train.txt
+++ b/banking_loan_approval/supportVectorMachine/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/all/requirements.txt
+++ b/build-package/certifaiReferenceModelServer/all/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3
 keras==2.3.1

--- a/build-package/certifaiReferenceModelServer/all/requirements_local.txt
+++ b/build-package/certifaiReferenceModelServer/all/requirements_local.txt
@@ -1,5 +1,5 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3
 Flask==1.1.1
 cortex-python==1.3.1

--- a/build-package/certifaiReferenceModelServer/bank_marketing/all/requirements.txt
+++ b/build-package/certifaiReferenceModelServer/bank_marketing/all/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/bank_marketing/decisionTree/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/bank_marketing/decisionTree/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/bank_marketing/decisionTree/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/bank_marketing/decisionTree/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/bank_marketing/logisticRegression/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/bank_marketing/logisticRegression/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/bank_marketing/logisticRegression/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/bank_marketing/logisticRegression/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/bank_marketing/multiLayerPerceptron/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/bank_marketing/multiLayerPerceptron/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/bank_marketing/multiLayerPerceptron/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/bank_marketing/multiLayerPerceptron/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/bank_marketing/supportVectorMachine/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/bank_marketing/supportVectorMachine/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/bank_marketing/supportVectorMachine/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/bank_marketing/supportVectorMachine/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/all/requirements.txt
+++ b/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/all/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/gradientBoosting/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/gradientBoosting/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/gradientBoosting/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/gradientBoosting/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/multiLayerPerceptron/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/multiLayerPerceptron/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/multiLayerPerceptron/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/multiLayerPerceptron/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/randomForest/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/randomForest/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/randomForest/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/randomForest/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/supportVectorMachine/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/supportVectorMachine/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/supportVectorMachine/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/banking_customer_churn_prediction/supportVectorMachine/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/banking_loan_approval/all/requirements.txt
+++ b/build-package/certifaiReferenceModelServer/banking_loan_approval/all/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/banking_loan_approval/decisionTree/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/banking_loan_approval/decisionTree/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/banking_loan_approval/decisionTree/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/banking_loan_approval/decisionTree/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/banking_loan_approval/logisticRegression/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/banking_loan_approval/logisticRegression/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/banking_loan_approval/logisticRegression/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/banking_loan_approval/logisticRegression/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/banking_loan_approval/multiLayerPerceptron/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/banking_loan_approval/multiLayerPerceptron/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/banking_loan_approval/multiLayerPerceptron/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/banking_loan_approval/multiLayerPerceptron/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/banking_loan_approval/supportVectorMachine/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/banking_loan_approval/supportVectorMachine/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/banking_loan_approval/supportVectorMachine/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/banking_loan_approval/supportVectorMachine/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/finance_income_prediction/all/requirements.txt
+++ b/build-package/certifaiReferenceModelServer/finance_income_prediction/all/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/finance_income_prediction/logisticRegression/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/finance_income_prediction/logisticRegression/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/finance_income_prediction/logisticRegression/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/finance_income_prediction/logisticRegression/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/finance_income_prediction/randomForest/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/finance_income_prediction/randomForest/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/finance_income_prediction/randomForest/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/finance_income_prediction/randomForest/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/all/requirements.txt
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/all/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/decisionTree/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/decisionTree/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/decisionTree/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/decisionTree/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/logisticRegression/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/logisticRegression/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/logisticRegression/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/logisticRegression/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/multiLayerPerceptron/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/multiLayerPerceptron/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/multiLayerPerceptron/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/multiLayerPerceptron/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/supportVectorMachine/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/supportVectorMachine/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/supportVectorMachine/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/healthcare_disease_prediction/supportVectorMachine/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/healthcare_heart_disease_prediction/all/requirements.txt
+++ b/build-package/certifaiReferenceModelServer/healthcare_heart_disease_prediction/all/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/healthcare_heart_disease_prediction/kNearestNeighbors/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/healthcare_heart_disease_prediction/kNearestNeighbors/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1

--- a/build-package/certifaiReferenceModelServer/healthcare_heart_disease_prediction/kNearestNeighbors/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/healthcare_heart_disease_prediction/kNearestNeighbors/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/healthcare_heart_disease_prediction/logisticRegression/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/healthcare_heart_disease_prediction/logisticRegression/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1

--- a/build-package/certifaiReferenceModelServer/healthcare_heart_disease_prediction/logisticRegression/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/healthcare_heart_disease_prediction/logisticRegression/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/healthcare_heart_disease_prediction/randomForest/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/healthcare_heart_disease_prediction/randomForest/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1

--- a/build-package/certifaiReferenceModelServer/healthcare_heart_disease_prediction/randomForest/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/healthcare_heart_disease_prediction/randomForest/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/all/requirements.txt
+++ b/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/all/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3
 keras==2.3.1

--- a/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/linearRegressionL1/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/linearRegressionL1/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/linearRegressionL1/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/linearRegressionL1/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/linearRegressionL2/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/linearRegressionL2/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/linearRegressionL2/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/linearRegressionL2/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/randomForest/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/randomForest/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/randomForest/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/randomForest/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/supportVectorRegression/requirements_predict.txt
+++ b/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/supportVectorRegression/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/supportVectorRegression/requirements_train.txt
+++ b/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/supportVectorRegression/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/build-package/requirements.txt
+++ b/build-package/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3
 keras==2.3.1

--- a/build-package/requirements_local.txt
+++ b/build-package/requirements_local.txt
@@ -1,5 +1,5 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3
 Flask==1.1.1
 cortex-python==1.3.1

--- a/build-package/setup.py
+++ b/build-package/setup.py
@@ -32,7 +32,7 @@ setup(name='cortex-certifai-reference-model-server',
       include_package_data=True,
       install_requires=[
         'numpy==1.16.3',
-        'scikit-learn==0.20.3',
+        'scikit-learn==0.23.1',
         'pandas==0.24.2',
         'Flask==1.1.1',
         'cortex-python==1.3.1',

--- a/finance_income_prediction/all/requirements.txt
+++ b/finance_income_prediction/all/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3
 xgboost==0.90

--- a/finance_income_prediction/logisticRegression/requirements_predict.txt
+++ b/finance_income_prediction/logisticRegression/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/finance_income_prediction/logisticRegression/requirements_train.txt
+++ b/finance_income_prediction/logisticRegression/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/finance_income_prediction/randomForest/requirements_predict.txt
+++ b/finance_income_prediction/randomForest/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/finance_income_prediction/randomForest/requirements_train.txt
+++ b/finance_income_prediction/randomForest/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/finance_income_prediction/xgBoost/requirements_predict.txt
+++ b/finance_income_prediction/xgBoost/requirements_predict.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3
 xgboost==0.90

--- a/finance_income_prediction/xgBoost/requirements_train.txt
+++ b/finance_income_prediction/xgBoost/requirements_train.txt
@@ -1,5 +1,5 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1
 xgboost==0.90

--- a/healthcare_disease_prediction/all/requirements.txt
+++ b/healthcare_disease_prediction/all/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/healthcare_disease_prediction/decisionTree/requirements_predict.txt
+++ b/healthcare_disease_prediction/decisionTree/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/healthcare_disease_prediction/decisionTree/requirements_train.txt
+++ b/healthcare_disease_prediction/decisionTree/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/healthcare_disease_prediction/logisticRegression/requirements_predict.txt
+++ b/healthcare_disease_prediction/logisticRegression/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/healthcare_disease_prediction/logisticRegression/requirements_train.txt
+++ b/healthcare_disease_prediction/logisticRegression/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/healthcare_disease_prediction/multiLayerPerceptron/requirements_predict.txt
+++ b/healthcare_disease_prediction/multiLayerPerceptron/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/healthcare_disease_prediction/multiLayerPerceptron/requirements_train.txt
+++ b/healthcare_disease_prediction/multiLayerPerceptron/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/healthcare_disease_prediction/supportVectorMachine/requirements_predict.txt
+++ b/healthcare_disease_prediction/supportVectorMachine/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/healthcare_disease_prediction/supportVectorMachine/requirements_train.txt
+++ b/healthcare_disease_prediction/supportVectorMachine/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/healthcare_heart_disease_prediction/all/requirements.txt
+++ b/healthcare_heart_disease_prediction/all/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/healthcare_heart_disease_prediction/kNearestNeighbors/requirements_predict.txt
+++ b/healthcare_heart_disease_prediction/kNearestNeighbors/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1

--- a/healthcare_heart_disease_prediction/kNearestNeighbors/requirements_train.txt
+++ b/healthcare_heart_disease_prediction/kNearestNeighbors/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/healthcare_heart_disease_prediction/logisticRegression/requirements_predict.txt
+++ b/healthcare_heart_disease_prediction/logisticRegression/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1

--- a/healthcare_heart_disease_prediction/logisticRegression/requirements_train.txt
+++ b/healthcare_heart_disease_prediction/logisticRegression/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/healthcare_heart_disease_prediction/randomForest/requirements_predict.txt
+++ b/healthcare_heart_disease_prediction/randomForest/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1

--- a/healthcare_heart_disease_prediction/randomForest/requirements_train.txt
+++ b/healthcare_heart_disease_prediction/randomForest/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/insurance_auto_insurance_claims/all/requirements.txt
+++ b/insurance_auto_insurance_claims/all/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3
 keras==2.3.1
 tensorflow==1.15.2

--- a/insurance_auto_insurance_claims/linearRegressionL1/requirements_predict.txt
+++ b/insurance_auto_insurance_claims/linearRegressionL1/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/insurance_auto_insurance_claims/linearRegressionL1/requirements_train.txt
+++ b/insurance_auto_insurance_claims/linearRegressionL1/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/insurance_auto_insurance_claims/linearRegressionL2/requirements_predict.txt
+++ b/insurance_auto_insurance_claims/linearRegressionL2/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/insurance_auto_insurance_claims/linearRegressionL2/requirements_train.txt
+++ b/insurance_auto_insurance_claims/linearRegressionL2/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/insurance_auto_insurance_claims/neuralNetwork/requirements_predict.txt
+++ b/insurance_auto_insurance_claims/neuralNetwork/requirements_predict.txt
@@ -1,5 +1,5 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3
 keras==2.3.1
 tensorflow==1.15.2

--- a/insurance_auto_insurance_claims/neuralNetwork/requirements_train.txt
+++ b/insurance_auto_insurance_claims/neuralNetwork/requirements_train.txt
@@ -1,5 +1,5 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1
 pandas==0.25.3
 tensorflow==1.15.2

--- a/insurance_auto_insurance_claims/randomForest/requirements_predict.txt
+++ b/insurance_auto_insurance_claims/randomForest/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/insurance_auto_insurance_claims/randomForest/requirements_train.txt
+++ b/insurance_auto_insurance_claims/randomForest/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1

--- a/insurance_auto_insurance_claims/supportVectorRegression/requirements_predict.txt
+++ b/insurance_auto_insurance_claims/supportVectorRegression/requirements_predict.txt
@@ -1,3 +1,3 @@
 numpy==1.17.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 pandas==0.25.3

--- a/insurance_auto_insurance_claims/supportVectorRegression/requirements_train.txt
+++ b/insurance_auto_insurance_claims/supportVectorRegression/requirements_train.txt
@@ -1,4 +1,4 @@
 numpy==1.17.3
 pandas==0.25.3
-scikit-learn==0.20.3
+scikit-learn==0.23.1
 scipy==1.3.1


### PR DESCRIPTION
Issue: https://github.com/CognitiveScale/certifai/issues/2379

The above issue (and the Veracode issue  https://github.com/CognitiveScale/certifai/issues/2183) relate to updating scikit-learn reference-model package, but I'm a little hesitant to be using different versions of `scikit-learn` in the package and in the examples so this is also updating all the requirement files.

If anyone thinks that only the package should be updated, then I'll rollback the last commit.

I've verified that train & predicts work fine with:
* Local builds (only checked all - not individual models)
* s2i builds (only checked all - not individual models)
* Package builds
