### PR TITLE
Fix svr model so its actually SVR not random forest

### DIFF
--- a/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/supportVectorRegression/train.py
+++ b/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/supportVectorRegression/train.py
@@ -6,8 +6,8 @@ from sklearn.svm import SVR
 from sklearn.metrics import r2_score
 import pandas as pd
 import numpy as np
-from insurance_auto_insurance_claims.common_utils.train_utils import CategoricalEncoder
-from utils.encode_decode import pickle_model
+from certifaiReferenceModelServer.insurance_auto_insurance_claims.common_utils.train_utils import CategoricalEncoder
+from certifaiReferenceModelServer.utils.encode_decode import pickle_model
 
 RANDOM_SEED = 0
 

--- a/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/supportVectorRegression/train.py
+++ b/build-package/certifaiReferenceModelServer/insurance_auto_insurance_claims/supportVectorRegression/train.py
@@ -2,12 +2,12 @@ from cortex import Cortex, Message
 import json
 import sys
 import random
-from sklearn.ensemble import RandomForestRegressor
+from sklearn.svm import SVR
 from sklearn.metrics import r2_score
 import pandas as pd
 import numpy as np
-from certifaiReferenceModelServer.insurance_auto_insurance_claims.common_utils.train_utils import CategoricalEncoder
-from certifaiReferenceModelServer.utils.encode_decode import pickle_model
+from insurance_auto_insurance_claims.common_utils.train_utils import CategoricalEncoder
+from utils.encode_decode import pickle_model
 
 RANDOM_SEED = 0
 
@@ -52,18 +52,14 @@ def train(msg):
 
     # start model training
 
-    rf = RandomForestRegressor(
-        n_estimators=10, max_depth=11, bootstrap=True, random_state=RANDOM_SEED
-    )
-    rf.fit(X_train, y_train)
-    y_pred = rf.predict(X_test)
-    rf_err = ((y_test - y_pred) ** 2).sum()  # Prediction error
-
+    svr = SVR()
+    svr.fit(X_train, y_train)
+    y_pred = svr.predict(X_test)
     err = r2_score(y_test, y_pred)
 
     model_binary = f"models/{save_model_as}.pkl"
     pickle_model(
-        rf, scaler, "Random forest", err, "Random forest Regressor", model_binary
+        svr, scaler, "Support vector regressor", err, "Support vector regressor", model_binary
     )
     print(err)
     return f"model: {model_binary}"

--- a/build-package/setup.py
+++ b/build-package/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup
 with open('README.md', 'r') as f:
     long_description = f.read()
 
-__version__ = '1.2.15'
+__version__ = '1.3.3'
 
 setup(name='cortex-certifai-reference-model-server',
       description="Python Package for the CognitiveScale Cortex Certifai Reference Models",

--- a/insurance_auto_insurance_claims/supportVectorRegression/train.py
+++ b/insurance_auto_insurance_claims/supportVectorRegression/train.py
@@ -2,7 +2,7 @@ from cortex import Cortex, Message
 import json
 import sys
 import random
-from sklearn.ensemble import RandomForestRegressor
+from sklearn.svm import SVR
 from sklearn.metrics import r2_score
 import pandas as pd
 import numpy as np
@@ -52,18 +52,14 @@ def train(msg):
 
     # start model training
 
-    rf = RandomForestRegressor(
-        n_estimators=10, max_depth=11, bootstrap=True, random_state=RANDOM_SEED
-    )
-    rf.fit(X_train, y_train)
-    y_pred = rf.predict(X_test)
-    rf_err = ((y_test - y_pred) ** 2).sum()  # Prediction error
-
+    svr = SVR()
+    svr.fit(X_train, y_train)
+    y_pred = svr.predict(X_test)
     err = r2_score(y_test, y_pred)
 
     model_binary = f"models/{save_model_as}.pkl"
     pickle_model(
-        rf, scaler, "Random forest", err, "Random forest Regressor", model_binary
+        svr, scaler, "Support vector regressor", err, "Support vector regressor", model_binary
     )
     print(err)
     return f"model: {model_binary}"


### PR DESCRIPTION
I was doing some testing and discovered that the scores for RF and SVR auto-insurance models were identical. Sure enough - thats because they were both identical RF models. This fixes that. 

Sadly the SVR model runs sooo slowly (one predict per second-ish) that I am also going to remove it from the standard scan definition so the reports can be regenerated in a reasonable time.