### PR TITLE
Address dependabot warning re tensorflow

### DIFF
--- a/all/requirements.txt
+++ b/all/requirements.txt
@@ -2,5 +2,5 @@ numpy==1.18.4
 scikit-learn==0.23.1
 pandas==0.25.3
 xgboost==0.90
+tensorflow==2.2.3
 keras==2.3.1
-tensorflow==1.15.4

--- a/all/requirements_local.txt
+++ b/all/requirements_local.txt
@@ -4,5 +4,5 @@ pandas==0.25.3
 Flask==1.1.1
 cortex-python==1.3.1
 xgboost==0.90
+tensorflow==2.2.3
 keras==2.3.1
-tensorflow==1.15.4

--- a/insurance_auto_insurance_claims/all/requirements.txt
+++ b/insurance_auto_insurance_claims/all/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.18.4
 scikit-learn==0.23.1
 pandas==0.25.3
+tensorflow==2.2.3
 keras==2.3.1
-tensorflow==1.15.4

--- a/insurance_auto_insurance_claims/neuralNetwork/requirements_predict.txt
+++ b/insurance_auto_insurance_claims/neuralNetwork/requirements_predict.txt
@@ -1,5 +1,5 @@
 numpy==1.18.4
 scikit-learn==0.23.1
 pandas==0.25.3
+tensorflow==2.2.3
 keras==2.3.1
-tensorflow==1.15.4

--- a/insurance_auto_insurance_claims/neuralNetwork/requirements_train.txt
+++ b/insurance_auto_insurance_claims/neuralNetwork/requirements_train.txt
@@ -2,5 +2,5 @@ numpy==1.18.4
 scikit-learn==0.23.1
 scipy==1.3.1
 pandas==0.25.3
-tensorflow==1.15.4
+tensorflow==2.2.3
 keras==2.3.1

--- a/insurance_auto_insurance_claims/neuralNetwork/train.py
+++ b/insurance_auto_insurance_claims/neuralNetwork/train.py
@@ -1,4 +1,4 @@
-""" 
+"""
 Copyright (c) 2020. Cognitive Scale Inc. All rights reserved.
 Licensed under CognitiveScale Example Code License https://github.com/CognitiveScale/certifai-reference-models/blob/450bbe33bcf2f9ffb7402a561227963be44cc645/LICENSE.md
 """
@@ -13,6 +13,8 @@ os.environ["PYTHONHASHSEED"] = str(RANDOM_SEED)
 import random
 import numpy as np
 from tensorflow import set_random_seed
+# note we cannot use the recommended tensorflow.keras here due to
+# https://github.com/tensorflow/tensorflow/issues/34697
 from keras.models import Sequential
 from keras.layers import Dense
 from sklearn.metrics import r2_score


### PR DESCRIPTION
Dependabot flagged a tensorflow vulnerability in our docker-based reference models. This does not impact the reference models we ship in the product because we don't include the tensorflow model there.

I updated to the last version of tensorflow that is compatible with the separate installation of keras, i.e., if we need to upgrade again we will need to use the workaround suggested in https://github.com/tensorflow/tensorflow/issues/34697 or hope that they have incorporated a fix into tf.keras so it is picklable.