### PR TITLE
4617 & 4640: Use common base image for Certifai enterprise (Python) containers and remove conda from runtime container

### DIFF
--- a/Dockerfile.c12e-ci.cortex-certifai-reference-model-server.ubi8
+++ b/Dockerfile.c12e-ci.cortex-certifai-reference-model-server.ubi8
@@ -7,20 +7,14 @@ FROM c12e/certifai:base-build AS build
 COPY artifacts/packages/cortex-certifai-reference-model-server-*.zip \
        /tmp/
 
-RUN conda run -n certifai pip install --no-cache-dir --upgrade pip
-RUN conda run -n certifai pip install --no-cache-dir \
-     $(find /tmp -name cortex-certifai-reference-model-server-*.zip)
-
-# Use conda-pack to save the conda env in a standalone environment (/venv).
-# NOTE: The environment must be in the same path in the runtime container.
-RUN conda-pack -n certifai --ignore-missing-files -o /tmp/env.tar && \
-  mkdir /venv && \
-  cd /venv && tar xf /tmp/env.tar && \
-  rm /tmp/env.tar
-
-# 'Un-pack the environment' - i.e. fix the path prefixes in the environment, so the environment is
-# equivalent to having been installed at /venv.
-RUN  /venv/bin/conda-unpack
+RUN conda run -n certifai pip install --no-cache-dir --upgrade pip && \
+    conda run -n certifai pip install --no-cache-dir \
+      $(find /tmp -name cortex-certifai-reference-model-server-*.zip) && \
+    conda-pack -n certifai --ignore-missing-files -o /tmp/env.tar && \
+    mkdir /venv && \
+    cd /venv && tar xf /tmp/env.tar && \
+    rm /tmp/env.tar && \
+    /venv/bin/conda-unpack
 
 ####################################################
 ## Runtime container

--- a/Dockerfile.c12e-ci.cortex-certifai-reference-model-server.ubi8
+++ b/Dockerfile.c12e-ci.cortex-certifai-reference-model-server.ubi8
@@ -1,4 +1,32 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+####################################################
+## Build container
+####################################################
+
+FROM c12e/certifai:base-build AS build
+
+COPY artifacts/packages/cortex-certifai-reference-model-server-*.zip \
+       /tmp/
+
+RUN conda run -n certifai pip install --no-cache-dir --upgrade pip
+RUN conda run -n certifai pip install --no-cache-dir \
+     $(find /tmp -name cortex-certifai-reference-model-server-*.zip)
+
+# Use conda-pack to save the conda env in a standalone environment (/venv).
+# NOTE: The environment must be in the same path in the runtime container.
+RUN conda-pack -n certifai --ignore-missing-files -o /tmp/env.tar && \
+  mkdir /venv && \
+  cd /venv && tar xf /tmp/env.tar && \
+  rm /tmp/env.tar
+
+# 'Un-pack the environment' - i.e. fix the path prefixes in the environment, so the environment is
+# equivalent to having been installed at /venv.
+RUN  /venv/bin/conda-unpack
+
+####################################################
+## Runtime container
+####################################################
+
+FROM c12e/certifai:base-runtime AS runtime
 
 LABEL release=1 \
   name="cortex-certifai-reference-models-server" \
@@ -8,46 +36,20 @@ LABEL release=1 \
   description="Reference Model Server for Cognitive Scale's Cortex Certifai" \
   com.cognitivescale.license_terms="https://www.cognitivescale.com/legal-information/"
 
+# Copy the python environment from the build stage
+COPY --from=build /venv /venv
+
+# Activate the python env in the .bashrc and so python, pip, certifai, etc. are available when running the container
+RUN echo 'source /venv/bin/activate' >> ~/.bashrc
+SHELL ["/bin/bash", "--login", "-c"]
+
 COPY licenses /licenses
-COPY artifacts/packages/cortex-certifai-reference-model-server-*.zip \
-       /tmp/
-
-WORKDIR /app
-
-USER root
-
-RUN microdnf update -y && microdnf install wget findutils -y
-
-# Create '/conda' folder '.bashrc' for the non-root user, otherwise they cannot use conda
-RUN mkdir /conda && chown -R 1001 /conda && chmod -R u+w /conda && \
-    touch //.bashrc && chown -R 1001 //.bashrc && chmod u+w //.bashrc
-
-USER 1001
-
-# Install conda
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh && \
-    /bin/bash /tmp/miniconda.sh -b -p /conda -u && \
-    rm /tmp/miniconda.sh
-ENV PATH=/conda/bin:$PATH
-
-# Create a conda env
-RUN conda create -n python38 python=3.8 -y
-
-# Activate conda (and initialize) when we start the container.
-RUN echo 'eval "$(conda shell.bash hook)"' >> ~/.bashrc && \
-    echo "conda activate python38" >> ~/.bashrc
-
-
-RUN /conda/envs/python38/bin/pip install --upgrade pip
-
-RUN /conda/envs/python38/bin/pip install --no-cache-dir \
-     $(find /tmp -name cortex-certifai-reference-model-server-*.zip)
 
 USER root
 RUN mkdir -p /app && chown -R 1001 /app
 USER 1001
 
-ENV PATH=/conda/envs/python38/bin:$PATH
+WORKDIR /app
 
 EXPOSE 5111
-CMD ["/conda/envs/python38/bin/startCertifaiModelServer"]
+CMD ["startCertifaiModelServer"]


### PR DESCRIPTION
This pull request applies the changes described in https://github.com/CognitiveScale/certifai/pull/4656 to the reference model containers.

Related Issue: https://github.com/CognitiveScale/certifai/issues/4640#issuecomment-1273551259