### PR TITLE
Rebuild certifai reference models GoCD builder image - upgrade to Python 3.8 instead of 3.6

### DIFF
--- a/Dockerfile.gocd-builder-image
+++ b/Dockerfile.gocd-builder-image
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial-20191212
+FROM ubuntu:focal-20230301
 
 RUN apt-get update && \
     apt-get install -y apt-transport-https ca-certificates curl software-properties-common lxc iptables && \
@@ -17,7 +17,7 @@ RUN apt install -y rsync make
 
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
-    apt-get install --yes python3.6 python3-pip python3-dev && \
+    apt-get install --yes python3.8 python3-pip python3-dev && \
     pip3 install --upgrade pip && \
     pip3 install virtualenv
 

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ function local_docker() {
 # This runs inside a linux docker container
 function package_build() {
     cd build-package
-    virtualenv -p python3.6 reference_models
+    virtualenv -p python3.8 reference_models
     source ./reference_models/bin/activate
     make build_package
 }

--- a/c12e-ci.yml
+++ b/c12e-ci.yml
@@ -1,3 +1,3 @@
 builder:
-    image: c12e/certifai:reference_models_builder-20200204_5
+    image: c12e/certifai:reference_models_builder-20230308
     command: "./build.sh CI"


### PR DESCRIPTION
Fixes https://gocd.dci-dev.dev-eks.insights.ai/go/tab/build/detail/certifai-reference-models-ubi/15/build/2/Build